### PR TITLE
Added comments to webpack.config and source files

### DIFF
--- a/98 Commented/03 Environments/02 CSS Modules/src/averageComponent.jsx
+++ b/98 Commented/03 Environments/02 CSS Modules/src/averageComponent.jsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {getAvg} from './averageService';
+import classNames from './averageComponentStyles'; // When using CSS Modules, Webpack will create a bundle file for our CSS file that we can import to refer our styles/classNames
+
+export class AverageComponent extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      scores: [90, 75, 60, 99, 94, 30],
+      average: 0,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({average: getAvg(this.state.scores)});
+  }
+
+  render() {
+    /* The classNames const variable holds all the styling rules defined in this component's CSS file. We can access the contents of this variable in React/JSX using {} as usual.
+       classNames is an object that has a property defined for each one of the CSS classes defined in the CSS file. These properties' keys are strings with the same name as those
+       CSS classes by default, so we would need to access them in this way in javascript: myClass = classNames['my-class'];. However, since we are setting the camelCase option of css-loader
+       to true, we actually retrieve these classes using this notation instead: myClass = classNames.myClass; 
+       
+       In the case of the jumbotron, since it is actually a global class, we want to use a string literal for it, so we use string interpolation to assign both classes to our span element:
+       jumbotron (a literal) and classNames.resultBackground (a variable)
+       */
+    return (
+      <div>
+        <span className={classNames.resultBackground}>
+          Students average: {this.state.average}
+        </span>
+
+        <span className={`jumbotron ${classNames.resultBackground}`}>
+          Jumbotron students average: {this.state.average}
+        </span>
+      </div>
+    );
+  }
+}

--- a/98 Commented/03 Environments/02 CSS Modules/src/averageComponentStyles.scss
+++ b/98 Commented/03 Environments/02 CSS Modules/src/averageComponentStyles.scss
@@ -1,0 +1,15 @@
+$background: teal;
+$jumbotronBackground: darkseagreen;
+
+.result-background { // We are using the same name for different CSS rules in separate CSS files
+  background-color: $background;
+}
+
+/* The example below illustrates how to use our custom classes alongside those from other vendors. In this case, we want our CSS selector to target an elemeent with jumbotron class
+ that has also the custom class result-background applied. The problem here is that our selector will also be transformed by webpack following the naming convention we had specified
+ ([name_of_the_css_file]__[name_of_the_css_class]__[some_hash]). Thus, it would never target the css class that we are importing from Bootstrap. In order to prevent that, we need to
+ add the :global() modifier to tell webpack that we want to refer a class from outside this CSS module*/
+:global(.jumbotron).result-background {
+  background-color: $jumbotronBackground;
+  display: block;
+}

--- a/98 Commented/03 Environments/02 CSS Modules/src/totalScoreComponent.jsx
+++ b/98 Commented/03 Environments/02 CSS Modules/src/totalScoreComponent.jsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import {getTotalScore} from './averageService';
+import classNames from './totalScoreComponentStyles'; // When using CSS Modules, Webpack will create a bundle file for our CSS file that we can import to refer our styles/classNames
+
+export class TotalScoreComponent extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      scores: [10, 20, 30, 40, 50],
+      totalScore: 0,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({totalScore: getTotalScore(this.state.scores)});
+  }
+
+  render() {
+    /* The classNames const variable holds all the styling rules defined in this component's CSS file. We can access the contents of this variable in React/JSX using {} as usual.
+       classNames is an object that has a property defined for each one of the CSS classes defined in the CSS file. These properties' keys are strings with the same name as those
+       CSS classes by default, so we would need to access them in this way in javascript: myClass = classNames['my-class'];. However, since we are setting the camelCase option of css-loader
+       to true, we actually retrieve these classes using this notation instead: myClass = classNames.myClass; 
+       */
+    return (
+      <div>
+        <span className={classNames['result-background']}>
+          Students total score: {this.state.totalScore}
+        </span>
+      </div>
+    );
+  }
+}

--- a/98 Commented/03 Environments/02 CSS Modules/src/totalScoreComponentStyles.scss
+++ b/98 Commented/03 Environments/02 CSS Modules/src/totalScoreComponentStyles.scss
@@ -1,0 +1,5 @@
+$background: indianred;
+
+.result-background {
+  background-color: $background; // We are using the same name for different CSS rules in separate CSS files
+}

--- a/98 Commented/03 Environments/02 CSS Modules/webpack.config.js
+++ b/98 Commented/03 Environments/02 CSS Modules/webpack.config.js
@@ -1,0 +1,121 @@
+var path = require('path');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+var basePath = __dirname;
+
+module.exports = {
+  context: path.join(basePath, 'src'),
+  resolve: {
+    extensions: ['.js', '.jsx', '.scss'], 
+    /* We are no longer using appStyles to add our custom style .css/scss/less files.
+     Thus, we need to add the corresponding .scss extension to the list of files we want to send to the pipeline */
+  },
+  entry: {
+    app: './students.jsx',
+    vendor: [
+      'react',
+      'react-dom',
+    ],
+    vendorStyles: [
+      '../node_modules/bootstrap/dist/css/bootstrap.css',
+      /* Notice that we are still using webpack entry point to handle 3pp stylesheets*/
+    ],
+  },
+  output: {
+    path: path.join(basePath, 'dist'),
+    filename: '[chunkhash].[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.scss$/,
+        exclude: /node_modules/,
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            {
+              loader: 'css-loader',
+              /*css-loader is the loader that processes our CSS files (sass-loader will digest our SCSS files into CSS prior to the execution of this loader)
+                In order to use CSS Modules, we have added the following options to this loader stage:
+                 - modules: setting this property to true enables local scoped CSS selectors
+                 - localIdentName: this property sets how each CSS class will be referenced in the final HTML code generated. We are using the following variables in order
+                   to ensure that our class names translate into unique ids
+                     + [name]: this will be replaced by the name of the .css filee (which should be the name of our Component if we are following proper Component Driven Development)
+                     + [local]: the local name in the .css file for a given CSS class
+                     + [hash]: a hash value added to ensure that the id remains unique.
+                 - camelCase: in order to reference our styles in the jsx files using camel case notation instead of the default kebab case (e.g. classNames.someClass vs classNames['some-class']
+                 - sourceMap: set to true in case we want to show our CSS styles for debugging purposes (not included in this sample)*/
+              options: {
+                modules: true,
+                localIdentName: '[name]__[local]___[hash:base64:5]',
+                camelCase: true,
+              },
+            },
+            { loader: 'sass-loader', }, // Note that this loader will transform our .scss files into .css prior to thee execution of the css-loader block
+          ],
+        }),
+      },
+      {
+        test: /\.css$/,
+        include: /node_modules/,
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: {
+            loader: 'css-loader',
+          },
+        }),
+      },
+      // Loading glyphicons => https://github.com/gowravshekar/bootstrap-webpack
+      // Using here url-loader and file-loader
+      {
+        test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'url-loader?limit=10000&mimetype=application/font-woff'
+      },
+      {
+        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'url-loader?limit=10000&mimetype=application/octet-stream'
+      },
+      {
+        test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'file-loader'
+      },
+      {
+        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+        loader: 'url-loader?limit=10000&mimetype=image/svg+xml'
+      },
+    ],
+  },
+  // For development https://webpack.js.org/configuration/devtool/#for-development
+  devtool: 'inline-source-map',
+  devServer: {
+    port: 8080,
+  },
+  plugins: [
+    //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: 'index.html', //Name of file in ./dist/
+      template: 'index.html', //Name of template in ./src
+      hash: true,
+    }),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      names: ['vendor', 'manifest'],
+    }),
+    new webpack.HashedModuleIdsPlugin(),
+    new ExtractTextPlugin({
+      filename: '[chunkhash].[name].css',
+      disable: false,
+      allChunks: true,
+    }),
+  ],
+};


### PR DESCRIPTION
Hello there,

I have added some inline comments for the example regarding the use of webpack and css-loader to enable CSS modules in a React app.
Summary of changes performed:
  - created a copy of the files changed for the 03 Environments / 02 CSS Modules example under 98 Commented folder.
  - populated those files with suitable comments to serve as an inline guide.