### PR TITLE
Feature/01 custom css

### DIFF
--- a/version 4/00 intro/05 jquery/README.md
+++ b/version 4/00 intro/05 jquery/README.md
@@ -1,0 +1,106 @@
+# 05 JQuery
+
+So far we have made good progress on our journey... but we are lacking one of the
+basic pillars of web development, consuming third party libraries.
+
+In this demo we will install a legacy library (jquery) via npm, define it as global, and use it. Finally we will end up creating a separate bundle for libraries.
+
+We will start from sample _00 Intro/03 Output_.
+
+Summary steps:
+ - Install jquery via npm.
+ - Setup a global alias ($).
+ - Create some sample code using this library.
+ - Break into two bundles `app.js` and `vendor.js`.  
+
+# Steps to build it
+
+## Prerequisites
+
+Prerequisites, you will need to have nodejs installed (at least v 8.9.2) on your computer. If you want to follow this guide steps you will need to take as starting point sample _04 Output_.
+
+## steps
+
+- `npm install` to install previous sample packages:
+
+```
+npm install
+```
+- Let's start by downloading the jquery library via npm. In this case we will execute the following command on the command prompt ```npm install jquery --save```.
+**note down**: this time we are not adding the `-d` suffix to the parameter, this time the jquery package is a dependency of the web app not of the build process.
+
+```
+npm install jquery --save
+```
+
+It automatically adds that entry to our _package.json_.
+
+_package.json_
+
+```diff
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.3",
+    "babel-preset-env": "^1.6.1",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^2.0.9",
+    "html-webpack-plugin": "^3.0.4",
+    "webpack-dev-server": "^3.1.0"
+  },
++  "dependencies": {    
++    "jquery": "^3.3.1"    
++  }
+```
+
+- Since this is a legacy library it expects to have a global variable available.
+Instead of assigning this manually let's define it in the `webpack.config.js`. file.
+
+- First we will require an import "webpack" at the top of the file:
+
+```diff
+var HtmlWebpackPlugin = require('html-webpack-plugin');
++ var webpack = require('webpack');
+
+module.exports = {
+```
+
+- Then we will use a plugin from webpack to define jQuery and $ as global variables.
+
+```diff
+  plugins: [
+    //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: 'index.html', //Name of file in ./dist/
+      template: 'index.html', //Name of template in ./src
+      hash:true,
+    }),
++   new webpack.ProvidePlugin({
++     $: "jquery",
++     jQuery: "jquery"
++   }),    
+  ],
+```
+
+- Now it's ready to be used. Just to test it, let's change the background color of the page body to blue. Let's change the background of the body element using jquery:
+
+_./src_
+
+```diff
+import {getAvg} from "./averageService";
+
++ $('body').css('background-color', 'lightSkyBlue');
+
+const scores = [90, 75, 60, 99, 94, 30];
+const averageScore = getAvg(scores);
+
+const messageToDisplay = `average score ${averageScore}`;
+
+document.write(messageToDisplay);
+
+```
+
+- Now we can just execute the app (```npm start```) and check how the background of the page has changed from white to blue.
+
+```bash
+npm start
+```

--- a/version 4/00 intro/05 jquery/averageService.js
+++ b/version 4/00 intro/05 jquery/averageService.js
@@ -1,0 +1,7 @@
+export function getAvg(scores) {
+    return getTotalScore(scores) / scores.length;
+}
+
+function getTotalScore(scores) {
+    return scores.reduce((score, count) => score + count);
+}

--- a/version 4/00 intro/05 jquery/index.html
+++ b/version 4/00 intro/05 jquery/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Webpack 4.x by sample</title>
+  </head>
+  <body>
+    Hello Webpack 4!
+  </body>
+</html>

--- a/version 4/00 intro/05 jquery/package.json
+++ b/version 4/00 intro/05 jquery/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "boilerplate",
+  "version": "1.0.0",
+  "description": "In this sample we are going to setup a web project that can be easily managed by webpack.",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --mode development --open",
+    "build": "webpack  --mode development"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.3",
+    "babel-preset-env": "^1.6.1",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^2.0.9",
+    "html-webpack-plugin": "^3.0.4",
+    "webpack-dev-server": "^3.1.0"
+  },
+  "dependencies": {    
+    "jquery": "^3.3.1"    
+  }
+}

--- a/version 4/00 intro/05 jquery/students.js
+++ b/version 4/00 intro/05 jquery/students.js
@@ -1,0 +1,10 @@
+// Let's use some ES6 features
+import {getAvg} from "./averageService";
+
+$('body').css('background-color', 'lightSkyBlue');
+
+const scores = [90, 75, 60, 99, 94, 30];
+const averageScore = getAvg(scores);
+const messageToDisplay = `average score ${averageScore}`;
+
+document.write(messageToDisplay);

--- a/version 4/00 intro/05 jquery/webpack.config.js
+++ b/version 4/00 intro/05 jquery/webpack.config.js
@@ -1,0 +1,32 @@
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: ['./students.js'],
+  output: {
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+    ],
+  },
+  plugins: [
+    //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: 'index.html', //Name of file in ./dist/
+      template: 'index.html', //Name of template in ./src
+      hash: true,
+    }),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    }),
+
+  ],
+
+};

--- a/version 4/01 Styles/01 custom-css/README.md
+++ b/version 4/01 Styles/01 custom-css/README.md
@@ -163,7 +163,20 @@ pero entry point (chunk).
 
 ```
 
-- Now we need to configure the 
+- Now if we run a build
+
+```
+npm run build 
+``` 
+
+- We can check that we get three chunks vendor, app and appStyles.
+
+> This is a big change comparing to wepack 3, we had to use in the past commonChunks plugin to 
+do that, now webpack incorporate splitChunks plugin and automatically makes the decisitions for
+your, if you want to have more control over it: https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693
+
+- Now we can see tha the styles are enclosed in a js file, what if we want to keep it as a separated
+css file? We can make use of ExtractTextPlugin.
 
 *** WORK IN PROGRESS USE SPLIT CHUNKS instead of common chunks**
 

--- a/version 4/01 Styles/01 custom-css/README.md
+++ b/version 4/01 Styles/01 custom-css/README.md
@@ -1,0 +1,173 @@
+# 01 Custom CSS
+
+Let's get started working with styles.
+
+In this demo will create a custom CSS file (it will contain a simple css class
+that will setup a background color to red).
+
+We will start from sample _00 Intro/05 JQuery_.
+
+Summary steps:
+ - Create a custom css file.
+ - Install style loader and css loader packages.
+ - Configure webpackconfig.
+
+ # Steps to build it
+
+## Prerequisites
+
+Prerequisites, you will need to have nodejs (at least v 8.9.2) installed in your computer. If you want to follow this step guides you will need to take as starting point sample _00 Intro/05 JQuery_.
+
+## steps
+
+- `npm install` to install previous sample packages:
+
+```
+npm install
+```
+
+- Now let's create a simple CSS file that will add a red background when
+used on some e.g. div. (we will name it `mystyles.css`):
+
+_./mystyles.css_
+```css
+.red-background {
+ background-color: indianred;
+}
+```
+- And now we can just use this style directly in our HTML file (so far so good, if we run this project now we won't see this styles applied, we have to go through some webpack configuration), let's update `index.html`
+
+_./index.html_
+```diff
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Webpack 3.x by sample</title>
+  </head>
+  <body>
+    Hello Webpack 3!
++   <div class="red-background">
++     RedBackground stuff
++   </div>
+  </body>
+</html>
+```
+
+- Let's start installing `style-loader` and `css-loader` as dev dependencies.
+  - `css-loader` is for load `.css` files.
+  - `style-loader` is to insert styles in html file, so we can use these styles.
+
+```bash
+npm install style-loader css-loader --d
+```
+
+- Let's add this style to our entry point, first our entry point will hold more
+entries, but in this case we will define it as named entries.
+
+_webpack.config.js_
+
+```diff
+module.exports = {
+-  entry: ['./students.js'],
++  entry: ['./students.js', './mystyles.css'],
+  output: {
+    filename: 'bundle.js',
+  },
+```
+- If we launch a webpack build this will throw errors, that's because we haven't
+defined any loader to handle the css extension. To configure webpack
+properly let's add to the loader section a css entry and execute first
+the css-loader extension (handle css files), then the style-loader (add CSS to the down by injecting a styler class).
+
+_webpack.config.js_
+```diff
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
++     {
++       test: /\.css$/,
++       exclude: /node_modules/,
++       use: [
++         {
++           loader: 'style-loader',
++         },
++         {
++           loader: 'css-loader',
++         },
++       ],
++     },      
+    ],
+  },
+```
+- Now we can just execute the app (npm start) and check how the red background is
+being displayed on the div we have chosen.
+
+```bash
+npm start
+```
+
+- So far so good, if we make an _npm run build_ we can check that myStyles.css has been embedded
+into the _bundle.js_ file. In some case we may preffer divide the application into several 
+bundle files, let' see how can we chop this.
+
+> We will create three main groups: app, appStyles and vendor (for third partie libraries)
+
+- On the entry side let's create two groups
+
+_webpack.config.js_
+
+```diff
+module.exports = {
+-  entry: ['./students.js', './mystyles.css'],
++  entry: {
++    app: './students.js',
++    appStyles: [
++      './mystyles.css',
++    ],
++    vendor: [
++      'jquery',
++    ],
++  },
+
+  output: {
+```
+
+- In the output section let's create define a pattern for the output filenames (chunks)
+
+_webpack.config.json_
+
+```diff
+output: {
+-   filename: 'bundle.js',
++   filename: '[chunkhash].[name].js',
+},
+```
+
+*****
+
+- Now in the ouput file instead of creating a single file, we will create a file
+pero entry point (chunk).
+
+```diff
+  output: {
+-    filename: 'bundle.js',
++    filename: '[chunkhash].[name].js',
+  },
+
+```
+
+- Now we need to configure the 
+
+*** WORK IN PROGRESS USE SPLIT CHUNKS instead of common chunks**
+
+https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+
+
+

--- a/version 4/01 Styles/01 custom-css/README.md
+++ b/version 4/01 Styles/01 custom-css/README.md
@@ -178,9 +178,89 @@ your, if you want to have more control over it: https://gist.github.com/sokra/15
 - Now we can see tha the styles are enclosed in a js file, what if we want to keep it as a separated
 css file? We can make use of ExtractTextPlugin.
 
-*** WORK IN PROGRESS USE SPLIT CHUNKS instead of common chunks**
+> At the moment of this writing the current version of extract-text-webpack-plugin was not compatible
+with webpack 4, there was an alpha version available (that's why we will install it using the
+@next flag)
 
-https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+```bash
+npm install extract-text-webpack-plugin@next --d
+```
+
+> In the webpack roadmap (versions 4.x or 5) it supposed that the core webpack functionallity will
+implement the functionallity of this plugin.
+
+- Let's to configure loader:
+
+- Reference the plugin.
+
+_webpack.config.js_
+
+```diff
+var HtmlWebpackPlugin = require('html-webpack-plugin');
++ var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var webpack = require('webpack');
+
+module.exports = {
+```
+
+- Configure the loader for the _.css_ extension
+
+```diff
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+-        use: [
+-          {
+-            loader: 'style-loader',
+-          },
+-          {
+-            loader: 'css-loader',
+-          },
++       loader: ExtractTextPlugin.extract({
++         fallback: 'style-loader',
++         use: {
++           loader: 'css-loader',
++         },
++       }),
+        ],
+      },
+    ],
+  },
+```
+
+- Finally, add plugin configuration:
+  - `disable`: boolean to disable the plugin.
+  - `allChunks`: boolean to extract from all additional chunks too (by default it extracts only from the initial chunk(s)).
+
+```diff
+  plugins: [
+    //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: 'index.html', //Name of file in ./dist/
+      template: 'index.html', //Name of template in ./src
+      hash: true,
+    }),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    }),
+
+  ],
++   new ExtractTextPlugin({
++     filename: '[chunkhash].[name].css',
++     disable: false,
++     allChunks: true,
++   }),
+```
+
+- Running `webpack` again, it split into two files `appStyles.js` and `appStyles.css` and how to size decrease:
 
 
 

--- a/version 4/01 Styles/01 custom-css/README.md
+++ b/version 4/01 Styles/01 custom-css/README.md
@@ -262,5 +262,32 @@ module.exports = {
 
 - Running `webpack` again, it split into two files `appStyles.js` and `appStyles.css` and how to size decrease:
 
+- Maybe you have noticed that the _dist_ folder gets dirty, on every build we get some new files and files
+from previous build that have a different hash remain, in order to make a cleanup, we could just call
+an _rm_ or _delete_ command preivous to our _webpack_ command, but then our scripts would be platform
+dependant (windows or linux), there's a package called _rimraf_ that works multiplatform, le't configure 
+it.
 
+- First let's install it:
+
+```bash
+npm install rimraf -d
+```
+
+- Now in the _package.json_ file let's add an extra step
+
+```diff
+  "scripts": {
+    "start": "webpack-dev-server --mode development --open",
+-    "build": "webpack  --mode development"
++    "build": "rimraf dist && webpack  --mode development"
+  },
+```
+
+- Now if we run a build, we will see that dist folder is wiped and we get only the new generated fresh
+content.
+
+```bash
+npm run build
+```
 

--- a/version 4/01 Styles/01 custom-css/averageService.js
+++ b/version 4/01 Styles/01 custom-css/averageService.js
@@ -1,0 +1,7 @@
+export function getAvg(scores) {
+    return getTotalScore(scores) / scores.length;
+}
+
+function getTotalScore(scores) {
+    return scores.reduce((score, count) => score + count);
+}

--- a/version 4/01 Styles/01 custom-css/index.html
+++ b/version 4/01 Styles/01 custom-css/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Webpack 4.x by sample</title>
+</head>
+
+<body>
+  Hello Webpack 4!
+  <div class="red-background">
+    RedBackground stuff
+  </div>
+</body>
+</html>

--- a/version 4/01 Styles/01 custom-css/mystyles.css
+++ b/version 4/01 Styles/01 custom-css/mystyles.css
@@ -1,0 +1,3 @@
+.red-background {
+  background-color: indianred;
+ }

--- a/version 4/01 Styles/01 custom-css/package.json
+++ b/version 4/01 Styles/01 custom-css/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "boilerplate",
+  "version": "1.0.0",
+  "description": "In this sample we are going to setup a web project that can be easily managed by webpack.",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --mode development --open",
+    "build": "webpack  --mode development"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.3",
+    "babel-preset-env": "^1.6.1",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^2.0.9",
+    "html-webpack-plugin": "^3.0.4",
+    "webpack-dev-server": "^3.1.0"
+  },
+  "dependencies": {
+    "css-loader": "^0.28.10",
+    "jquery": "^3.3.1",
+    "style-loader": "^0.20.2"
+  }
+}

--- a/version 4/01 Styles/01 custom-css/package.json
+++ b/version 4/01 Styles/01 custom-css/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --mode development --open",
-    "build": "webpack  --mode development"
+    "build": "rimraf dist && webpack  --mode development"
   },
   "author": "",
   "license": "ISC",
@@ -22,6 +22,7 @@
     "css-loader": "^0.28.10",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "jquery": "^3.3.1",
+    "rimraf": "^2.6.2",
     "style-loader": "^0.20.2"
   }
 }

--- a/version 4/01 Styles/01 custom-css/package.json
+++ b/version 4/01 Styles/01 custom-css/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "css-loader": "^0.28.10",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "jquery": "^3.3.1",
     "style-loader": "^0.20.2"
   }

--- a/version 4/01 Styles/01 custom-css/students.js
+++ b/version 4/01 Styles/01 custom-css/students.js
@@ -1,0 +1,10 @@
+// Let's use some ES6 features
+import {getAvg} from "./averageService";
+
+$('body').css('background-color', 'lightSkyBlue');
+
+const scores = [90, 75, 60, 99, 94, 30];
+const averageScore = getAvg(scores);
+const messageToDisplay = `average score ${averageScore}`;
+
+document.write(messageToDisplay);

--- a/version 4/01 Styles/01 custom-css/webpack.config.js
+++ b/version 4/01 Styles/01 custom-css/webpack.config.js
@@ -1,0 +1,51 @@
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: {
+    app: './students.js',
+    appStyles: [
+      './mystyles.css',
+    ],
+    vendor: [
+      'jquery',
+    ],
+  },
+  output: {
+    filename: '[chunkhash].[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+      },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'style-loader',
+          },
+          {
+            loader: 'css-loader',
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    //Generate index.html in /dist => https://github.com/ampedandwired/html-webpack-plugin
+    new HtmlWebpackPlugin({
+      filename: 'index.html', //Name of file in ./dist/
+      template: 'index.html', //Name of template in ./src
+      hash: true,
+    }),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery"
+    }),
+
+  ],
+};

--- a/version 4/01 Styles/01 custom-css/webpack.config.js
+++ b/version 4/01 Styles/01 custom-css/webpack.config.js
@@ -1,4 +1,5 @@
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var webpack = require('webpack');
 
 module.exports = {
@@ -24,14 +25,12 @@ module.exports = {
       {
         test: /\.css$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'style-loader',
-          },
-          {
+        loader: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: {
             loader: 'css-loader',
           },
-        ],
+        }),
       },
     ],
   },
@@ -46,6 +45,10 @@ module.exports = {
       $: "jquery",
       jQuery: "jquery"
     }),
-
+       new ExtractTextPlugin({
+          filename: '[chunkhash].[name].css',
+          disable: false,
+          allChunks: true,
+        }),
   ],
 };


### PR DESCRIPTION
Custom css migrated, splitChunk makes automatic magic (common chunks replaced) issue with extract-text-webpack plugin, just installed the alpha version, but:

- In the future we will get a grip to styled component (seems like).
- Seems that extract text plugin will be gobbled up by further versions of webpack